### PR TITLE
Fixed the font size issue (flutter/flutter#14675)

### DIFF
--- a/lib/link_text.dart
+++ b/lib/link_text.dart
@@ -91,8 +91,8 @@ class _LinkTextState extends State<LinkText> {
       }
     });
 
-    return RichText(
-      text: TextSpan(children: textSpans),
+    return Text.rich(
+      TextSpan(children: textSpans),
       textAlign: widget.textAlign,
     );
   }


### PR DESCRIPTION
RichText widget is actually a raw text widget Text widget is based on (and might be renamed as such in future flutter/flutter#24722. The expected behavior is achieved by using Text.rich()