### PR TITLE
[Update] You can go to link without http, https

### DIFF
--- a/lib/link_text.dart
+++ b/lib/link_text.dart
@@ -47,7 +47,7 @@ class LinkText extends StatefulWidget {
 class _LinkTextState extends State<LinkText> {
   final _gestureRecognizers = <TapGestureRecognizer>[];
   final _regex = RegExp(
-      r"https?:\/\/(www\.)?[-a-zA-Z0-9@:%.,_\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\,+.~#?&//=]*)");
+      r"(https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%.,_\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\,+.~#?&//=]*)");
   final _shortenedRegex = RegExp(r"(.*)\?");
 
   @override

--- a/lib/link_text.dart
+++ b/lib/link_text.dart
@@ -57,11 +57,9 @@ class _LinkTextState extends State<LinkText> {
   }
 
   void _launchUrl(String url) async {
-    print(url.startsWith('http'));
     if (!url.startsWith('http')){
      url = "https://" + url; 
     }
-    print("url $url");
     if (widget.onLinkTap != null) {
       widget.onLinkTap!(url);
       return;

--- a/lib/link_text.dart
+++ b/lib/link_text.dart
@@ -57,9 +57,11 @@ class _LinkTextState extends State<LinkText> {
   }
 
   void _launchUrl(String url) async {
+    print(url.startsWith('http'));
     if (!url.startsWith('http')){
      url = "https://" + url; 
     }
+    print("url $url");
     if (widget.onLinkTap != null) {
       widget.onLinkTap!(url);
       return;

--- a/lib/link_text.dart
+++ b/lib/link_text.dart
@@ -57,6 +57,9 @@ class _LinkTextState extends State<LinkText> {
   }
 
   void _launchUrl(String url) async {
+    if (!url.startsWith('http')){
+     url = "https://" + url; 
+    }
     if (widget.onLinkTap != null) {
       widget.onLinkTap!(url);
       return;


### PR DESCRIPTION
If there are no words such as http, https, you can go to the link using this modification file.
I added 'http://' string. 

For example,

original link URL: github.com
changed link URL: https://github.com